### PR TITLE
feat: enhance UI for reservation and admin pages

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -3,15 +3,58 @@
 <head>
   <meta charset="utf-8">
   <title>カンパーニュ管理画面（簡素版）</title>
-  <style>
-    /* 管理画面用の簡素なスタイル */
-    body { font-family: system-ui; margin: 20px; }
-    .container { max-width: 1200px; margin: 0 auto; }
-    table { width: 100%; border-collapse: collapse; }
-    th, td { padding: 8px; border: 1px solid #ddd; text-align: left; }
-    button { padding: 8px 16px; margin: 4px; cursor: pointer; }
-  </style>
-</head>
+    <style>
+      /* 管理画面のスタイル改善 */
+      body {
+        font-family: system-ui, sans-serif;
+        background: #f4f1ed;
+        margin: 20px;
+      }
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+      input {
+        padding: 8px;
+        margin-right: 4px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: #fff;
+      }
+      th, td {
+        padding: 8px;
+        border: 1px solid #ddd;
+        text-align: left;
+      }
+      th { background: #fafafa; }
+      tbody tr:hover { background: #f1f1f1; }
+      button {
+        padding: 8px 16px;
+        margin: 4px;
+        cursor: pointer;
+        border: none;
+        border-radius: 4px;
+        background: #4a90e2;
+        color: #fff;
+      }
+      button:hover { opacity: 0.9; }
+      .toast {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        background: #333;
+        color: #fff;
+        padding: 10px 20px;
+        border-radius: 4px;
+        display: none;
+        z-index: 1000;
+      }
+      .toast.success { background: #38a169; }
+      .toast.error { background: #e53e3e; }
+    </style>
+  </head>
 <body>
   <div class="container">
     <h1>📊 管理ダッシュボード</h1>
@@ -43,10 +86,11 @@
       <button onclick="loadReservations()">🔄 更新</button>
       <button onclick="logout()">ログアウト</button>
     </div>
-  </div>
+    </div>
+    <div id="toast" class="toast"></div>
 
-  <!-- Firebase SDK -->
-  <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
+    <!-- Firebase SDK -->
+    <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore-compat.js"></script>
 
@@ -78,20 +122,22 @@
     });
 
     // ログイン
-    async function login() {
-      const email = document.getElementById('email').value;
-      const password = document.getElementById('password').value;
-      try {
-        await auth.signInWithEmailAndPassword(email, password);
-      } catch (error) {
-        alert('ログイン失敗: ' + error.message);
+      async function login() {
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        try {
+          await auth.signInWithEmailAndPassword(email, password);
+          showToast('ログインしました', 'success');
+        } catch (error) {
+          showToast('ログイン失敗: ' + error.message, 'error');
+        }
       }
-    }
 
-    // ログアウト
-    function logout() {
-      auth.signOut();
-    }
+      // ログアウト
+      function logout() {
+        auth.signOut();
+        showToast('ログアウトしました', 'success');
+      }
 
     // 予約一覧読み込み
     async function loadReservations() {
@@ -121,15 +167,26 @@
     }
 
     // ステータス更新
-    async function updateStatus(docId, status) {
-      try {
-        await db.collection('reservations').doc(docId).update({ status });
-        loadReservations();
-        alert('更新しました');
-      } catch (error) {
-        alert('更新エラー: ' + error.message);
+      async function updateStatus(docId, status) {
+        if (!confirm('状態を更新しますか？')) return;
+        try {
+          await db.collection('reservations').doc(docId).update({ status });
+          loadReservations();
+          showToast('更新しました', 'success');
+        } catch (error) {
+          showToast('更新エラー: ' + error.message, 'error');
+        }
       }
-    }
-  </script>
-</body>
+
+      function showToast(message, type = 'success', duration = 3000) {
+        const toast = document.getElementById('toast');
+        toast.textContent = message;
+        toast.className = 'toast ' + type;
+        toast.style.display = 'block';
+        setTimeout(() => {
+          toast.style.display = 'none';
+        }, duration);
+      }
+    </script>
+  </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,77 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>カンパーニュ予約（簡素版）</title>
-  <style>
-    /* 既存のスタイルを維持（省略） */
-  </style>
-</head>
+    <style>
+      /* 既存のスタイルを維持（省略） */
+      body {
+        font-family: system-ui, sans-serif;
+        background: #f4f1ed;
+        margin: 0;
+        line-height: 1.6;
+      }
+      .container {
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+        background: #fff;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      }
+      label {
+        display: block;
+        margin-bottom: 1rem;
+      }
+      input, select {
+        width: 100%;
+        padding: 8px;
+        margin-top: 4px;
+        box-sizing: border-box;
+      }
+      button {
+        background: #ff9b21;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        padding: 10px 20px;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #e0881c;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+      }
+      .toast {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        background: #333;
+        color: #fff;
+        padding: 10px 20px;
+        border-radius: 4px;
+        display: none;
+        z-index: 1000;
+      }
+      .toast.success { background: #38a169; }
+      .toast.error { background: #e53e3e; }
+      .back-to-top {
+        position: fixed;
+        bottom: 20px;
+        left: 20px;
+        display: none;
+        background: #ff9b21;
+        color: #fff;
+        border: none;
+        border-radius: 50%;
+        width: 40px;
+        height: 40px;
+        font-size: 1.2rem;
+        cursor: pointer;
+      }
+    </style>
+    </head>
 <body>
   <main class="container">
     <div id="reservationForm">
@@ -62,10 +129,12 @@
         <input type="hidden" name="_next" value="https://yoursite.com/success.html">
       </form>
     </div>
-  </main>
+    </main>
+    <div id="toast" class="toast"></div>
+    <button id="backToTop" class="back-to-top" aria-label="ページ上部へ戻る">▲</button>
 
-  <!-- Firebase SDK -->
-  <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
+    <!-- Firebase SDK -->
+    <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.5/firebase-firestore-compat.js"></script>
 
   <script>
@@ -558,6 +627,18 @@
       console.log(`トースト表示: ${message} (${type})`);
     }
 
+    // ページ上部へ戻るボタン
+    function setupBackToTop() {
+      const btn = document.getElementById('backToTop');
+      if (!btn) return;
+      window.addEventListener('scroll', () => {
+        btn.style.display = window.scrollY > 200 ? 'block' : 'none';
+      });
+      btn.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+    }
+
     // HTMLエスケープ
     function escapeHtml(text) {
       const div = document.createElement('div');
@@ -572,6 +653,7 @@
         console.error('初期化失敗:', error);
         showToast(`システム初期化に失敗しました: ${error.message}`, 'error');
       });
+      setupBackToTop();
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- improve reservation page with modern styling, toast messages, and back-to-top button
- refine admin dashboard look & feel, add toast notifications and confirmation prompts

## Testing
- `npm run test:rules` *(fails: sh: 1: firebase: not found)*
- `npm install firebase-tools` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b199d66f0483239d677844d2934351